### PR TITLE
RSLT::Stylesheet#safe_helper: a less confusing stylesheet curation method

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ group :development do
   gem 'activesupport'
   gem 'rake'
   gem 'i18n'
-  gem 'rspec', '>2.0.0'
+  gem 'rspec', '2.99'
   gem 'rcov', :platform => 'ruby_18'
   gem 'ruby-debug', :platform => 'ruby_18'
   gem 'byebug', :platform => 'ruby_21'

--- a/Gemfile
+++ b/Gemfile
@@ -10,4 +10,5 @@ group :development do
   gem 'rspec', '>2.0.0'
   gem 'rcov', :platform => 'ruby_18'
   gem 'ruby-debug', :platform => 'ruby_18'
+  gem 'byebug', :platform => 'ruby_21'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,7 +5,11 @@ GEM
       i18n (~> 0.6)
       multi_json (~> 1.0)
     builder (3.0.0)
+    byebug (2.7.0)
+      columnize (~> 0.3)
+      debugger-linecache (~> 1.2)
     columnize (0.3.6)
+    debugger-linecache (1.2.0)
     diff-lcs (1.1.3)
     i18n (0.6.0)
     linecache (0.46)
@@ -35,6 +39,7 @@ PLATFORMS
 DEPENDENCIES
   activesupport
   builder
+  byebug
   i18n
   nokogiri
   rake
@@ -43,4 +48,4 @@ DEPENDENCIES
   ruby-debug
 
 BUNDLED WITH
-   1.10.0
+   1.10.2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,7 +10,7 @@ GEM
       debugger-linecache (~> 1.2)
     columnize (0.3.6)
     debugger-linecache (1.2.0)
-    diff-lcs (1.1.3)
+    diff-lcs (1.2.5)
     i18n (0.6.0)
     linecache (0.46)
       rbx-require-relative (> 0.0.4)
@@ -19,14 +19,14 @@ GEM
     rake (0.9.2.2)
     rbx-require-relative (0.0.9)
     rcov (1.0.0)
-    rspec (2.9.0)
-      rspec-core (~> 2.9.0)
-      rspec-expectations (~> 2.9.0)
-      rspec-mocks (~> 2.9.0)
-    rspec-core (2.9.0)
-    rspec-expectations (2.9.1)
-      diff-lcs (~> 1.1.3)
-    rspec-mocks (2.9.0)
+    rspec (2.99.0)
+      rspec-core (~> 2.99.0)
+      rspec-expectations (~> 2.99.0)
+      rspec-mocks (~> 2.99.0)
+    rspec-core (2.99.2)
+    rspec-expectations (2.99.2)
+      diff-lcs (>= 1.1.3, < 2.0)
+    rspec-mocks (2.99.4)
     ruby-debug (0.10.4)
       columnize (>= 0.1)
       ruby-debug-base (~> 0.10.4.0)
@@ -44,7 +44,7 @@ DEPENDENCIES
   nokogiri
   rake
   rcov
-  rspec (> 2.0.0)
+  rspec (= 2.99)
   ruby-debug
 
 BUNDLED WITH

--- a/lib/rslt.rb
+++ b/lib/rslt.rb
@@ -1,7 +1,7 @@
 $:.unshift(File.dirname(__FILE__)) unless $:.include?(File.dirname(__FILE__)) || $:.include?(File.expand_path(File.dirname(__FILE__)))
 
 module RSLT
-  VERSION = '1.1.8'
+  VERSION = '1.1.10'
 end
 
 require 'rslt/stylesheet'

--- a/lib/rslt/stylesheet.rb
+++ b/lib/rslt/stylesheet.rb
@@ -54,6 +54,17 @@ module RSLT
       @helper_modules -= [mods].flatten
     end
 
+    def safe_helper(*mods)
+      original_modules = @helper_modules.dup
+      existing_modules = @helper_modules & mods # intersection
+      raise "Modules already loaded: #{existing_modules.join(', ')}" unless existing_modules.empty?
+      @helper_modules = @helper_modules.concat mods # we can concat cause there are no dupes
+
+      yield
+
+      @helper_modules = original_modules
+    end
+
     def within(selector)
       @within.push(selector)
       yield
@@ -90,6 +101,5 @@ module RSLT
       end
       mappings
     end
-
   end
 end

--- a/lib/rslt/stylesheet.rb
+++ b/lib/rslt/stylesheet.rb
@@ -56,12 +56,8 @@ module RSLT
 
     def safe_helper(*mods)
       original_modules = @helper_modules.dup
-      existing_modules = @helper_modules & mods # intersection
-      raise "Modules already loaded: #{existing_modules.join(', ')}" unless existing_modules.empty?
       @helper_modules = @helper_modules.concat mods # we can concat cause there are no dupes
-
       yield
-
       @helper_modules = original_modules
     end
 

--- a/lib/rslt/stylesheet.rb
+++ b/lib/rslt/stylesheet.rb
@@ -59,8 +59,7 @@ module RSLT
 
     def safe_helper(*mods)
       @safe = true
-      original_modules = @helper_module_sets.last.dup
-      @helper_module_sets.push(original_modules.concat mods)
+      @helper_module_sets.push mods
       yield
       @helper_module_sets.pop
     end
@@ -77,7 +76,7 @@ module RSLT
 
     def render_helpers
       if @safe
-        @helper_module_sets.last
+        @helper_module_sets.flatten
       else
         @helper_modules
       end

--- a/rslt.gemspec
+++ b/rslt.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = "rslt"
-  s.version = "1.1.9"
+  s.version = "1.1.10"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 2.2.0") if s.respond_to? :required_rubygems_version=
   s.authors = ["Daniel Heath"]

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,6 @@
 require 'rspec'
 require 'rspec/autorun'
+require 'byebug'
 
 $:.unshift(File.dirname(__FILE__) + '/../lib')
 require 'rslt'


### PR DESCRIPTION
#### Description

`RSLT::Stylesheet#safe_helper` solves inconsistencies with the existing `helper` method. `safe_helper` guarantees:
- helper order is always maintained
- helpers are not included prematurely 

`safe_helper` **does not** guarantee to be backwards compatible with `helper` stylesheets. On the other hand, stylesheets translated for `safe_helper` will be less confusing.
#### Testing notes

`excesselt_spec.rb` now has a `safe processing` section. Differences from `helper` behaviour are well described.
#### Not in scope

https://www.youtube.com/watch?v=Hn-enjcgV1o
#### Background

When using helpers, RSLT (1) adds them onto the helper list, (2) calls the block, and (3) removes the added helpers. In the case of nested helper blocks with duplicate helpers, step (3) removes _all instances_ of that helper. That is, it destructively changes available helpers.

In addition to removing a helper previously defined for the block, the order of helpers changes. Order is important because the helpers extend each other in the order they are found.

Additionally, `render` block calls in a parent block before any nested blocks are introduced have the helpers of that first nested block available to them as well! Consider the `Included modules` details provided by [this exception expectation](https://github.com/lonelyplanet/rslt/blob/d2f6da795c76947fd421aab60057c6c0a1c5f8e3/spec/excesselt_spec.rb#L100): the `render` call for that element is above the `helper`.

Consider this case (state of helpers given in comments):

```
helpers Paragraph, Poi, Map do
  # Paragraph, Poi, Map, Poi, Map, Poi
  helpers Poi do
    # Paragraph, Poi, Map, Poi, Map, Poi
  end
  # Paragraph > Map

  helpers Map, Poi do
    # Paragraph > Map > Map > Poi
  end
  # Paragraph 
end
```

Subsequent blocks no longer have a `Poi` helper. Subsequent use of the `Poi` helper pushes it to the end of the stack: In order to use `Map` and `Poi` helpers in that order, both need to be included, which results in both being removed after the second nested block.

This behaviour results in the remixer stylesheets being more complex than required: 
- nested helper blocks are repeatedly required to re-introduce previously declared helpers. 
- nested helper blocks cannot be used without altering the order of the called modules. (this destructive behaviour can be quite confusing to remixer novices!)
